### PR TITLE
bug: add missing Close() instruction

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -71,6 +71,7 @@ func CopyDir(source string, dest string) error {
 	if err != nil {
 		return err
 	}
+	defer dir.Close()
 
 	var errs []error
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -3,6 +3,7 @@ package fileutils
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 )
@@ -49,5 +50,24 @@ func TestCopyDir(t *testing.T) {
 	_, err = os.Stat(filepath.Join(folder, "everest.txt"))
 	if err != nil && err == os.ErrNotExist {
 		t.Error(err)
+	}
+}
+
+
+func TestCopyALotOfDirs(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(tempdir)
+	folder := filepath.Join(tempdir, "")
+
+	for i := 0; i < 5000; i++ {
+		go func () {
+			CopyDir("./testdata/hero", path.Join(folder, "ok"))
+		}()
+		go func () {
+			CopyDir("./testdata/mountain", path.Join(folder, "ok1"))
+		}()
 	}
 }

--- a/testdata/hero/batman.txt
+++ b/testdata/hero/batman.txt
@@ -1,0 +1,1 @@
+I'm Batman.


### PR DESCRIPTION
I'm using your library to copy a lot of directories (more than 170K) and I ran into an issue:

```bash
open /foo/bar/src/.gitkeep: too many open files
panic: open /foo/bar/src/.gitkeep: too many open files
goroutine 1 [running]:
log.Panic(0xc0023b79e0, 0x1, 0x1)
exit status 2
```

I checked that every opened file in my code was properly closed, but I still got the error. Then I wanted to know how many files were opened during the runtime:
```bash
lsof -p <PROCESS_ID>
```
and I noticed that a lot of file descriptors were describing directories, not files. So I reviewed your code and figured out you forgot to close a directory in [copy.go](https://github.com/hacdias/fileutils/blob/2c75a86d6f6bc907d720ddd70a16a58d03ecc230/copy.go#L69).

I wrote a unit test for that specific case but I don't know if it's relevant, I think this kind of issue depends on the architecture. Mine is:
```
Darwin Kernel Version: 19.5.0
ProductName:	Mac OS X
ProductVersion:	10.15.5
BuildVersion:	19F101
```